### PR TITLE
Phedex life cycle

### DIFF
--- a/Testbed/LifeCycle/examples/example-router-history.conf
+++ b/Testbed/LifeCycle/examples/example-router-history.conf
@@ -1,5 +1,10 @@
-# This example makes a representation of a dataset using the lifecycle dataprovider package
-# by Valentin.
+# This example gets the routing history information via the data service API
+# and merges it for the various instances that are supplied below
+# Two files are written 
+# RoutingHistoryOutputFile: the combined routing history information for all the instances
+# ExternalRates - file resembling what FileRouter can read as external rates override (but node names 
+#             instead of node IDs are written)
+
 %Lifecycle::Lite = (
 
   Name		=> 'PhEDEx Lifecycle Agent', # don't worry about this

--- a/perl_lib/PHEDEX/Testbed/Lifecycle/Datasvc.pm
+++ b/perl_lib/PHEDEX/Testbed/Lifecycle/Datasvc.pm
@@ -6,7 +6,6 @@ use POE;
 use Clone qw(clone);
 use Data::Dumper;
 use PHEDEX::CLI::UserAgent;
-use POSIX qw(strftime);
 
 our %params = (
 #	  cert_file => undef,
@@ -233,7 +232,7 @@ sub doneInject {
     if ( $self->{Debug} ) {
       $self->Alert("Injected: cannot understand output: ",Dumper($obj));
     } else {
-      $self->Alert("Injected: cannot understand output.",);
+      $self->Alert("Injected: cannot understand output.");
     }
     $payload->{report} = {
       status => 'error',


### PR DESCRIPTION
ADDED: Ability to get the RoutingHistory from several instances and merge the information, writing it to file
(use configuration file: example-router-history.conf)
