### PR TITLE
Fix grapher script currently hardcoded in PHEDEX-web.spec file. 

### DIFF
--- a/Documentation/WebSite/PlotConfig/tools/phedex-web.py
+++ b/Documentation/WebSite/PlotConfig/tools/phedex-web.py
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
-
 from graphtool.base.xml_config import XmlConfig
-import cherrypy
-
-if __name__ == '__main__':
-  xc = XmlConfig( file='$GRAPHTOOL_CONFIG_ROOT/website_prod.xml' ) 
-  cherrypy.server.quickstart()
-  cherrypy.engine.start() 
-  xc.globals['web'].kill()
-
+import sys, cherrypy
+xc = XmlConfig(file=sys.argv[1])
+cherrypy.quickstart()
+cherrypy.engine.start()
+xc.globals['web'].kill()


### PR DESCRIPTION
From hardcoded PHEDEX-web.spec: read config file from command line argument.

Once this is pushed upstream we can drop the hack from the build spec file.