### PR TITLE
Add support for DAVS-style URLs.

### DIFF
--- a/perl_lib/PHEDEX/Transfer/Backend/Job.pm
+++ b/perl_lib/PHEDEX/Transfer/Backend/Job.pm
@@ -372,6 +372,16 @@ sub PrepareJson
   #some clean up to avoid mis-interpretation of null values
   foreach (@jobfiles) { delete $_->{checksums} unless (defined $_->{checksums}); }
 
+  foreach (@jobfiles) {
+    if ($_->{destinations}[0] =~ /^davs:/) {
+      $_->{'metadata'} = {
+          'source-issuer' => 'https://scitokens.org/cms',
+          'dest-issuer' => 'https://scitokens.org/cms'
+      };
+    }
+  }
+
+
   my $local_client = qx/fts-transfer-submit --version --service http| cut -d':' -f2|cut -d' ' -f2/;
   chomp $local_client;
   my $jobparams = {

--- a/perl_lib/PHEDEX/Transfer/FTS3.pm
+++ b/perl_lib/PHEDEX/Transfer/FTS3.pm
@@ -29,7 +29,7 @@ sub new
     my $params = shift  || {};
 
     # Set my defaults where not defined by the derived class.
-    $params->{PROTOCOLS}           ||= [ 'srmv2' ];  # Accepted protocols
+    $params->{PROTOCOLS}           ||= [ 'srmv2', 'davs' ];  # Accepted protocols
     $params->{BATCH_FILES}         ||= 30;         # Max number of files per job
     $params->{NJOBS}               ||= 0;          # Max number of jobs.  0 for infinite.
     $params->{LINK_PEND}           ||= 50;         # Submit to FTS until this number of files per link are "pending"


### PR DESCRIPTION
This allows the FTS backend to be used for HTTPS-based transfers; in the case the DAVS protocol is used, a SciTokens provider is specified.